### PR TITLE
Add Death Tests for Arithmetic Operations

### DIFF
--- a/framework/spirv_simulator.cpp
+++ b/framework/spirv_simulator.cpp
@@ -1,17 +1,14 @@
 #include "spirv_simulator.hpp"
+#include "util.hpp"
 
 #include <iostream>
 #include <algorithm>
 #include <array>
-#include <cassert>
 #include <cmath>
 #include <iomanip>
 
 namespace SPIRVSimulator
 {
-
-#define assertx(msg) assert((void(msg), false))
-#define assertm(exp, msg) assert((void(msg), exp))
 
 constexpr uint32_t kWordCountShift = 16u;
 constexpr uint32_t kOpcodeMask     = 0xFFFFu;
@@ -3204,7 +3201,7 @@ void SPIRVSimulator::Op_LogicalNot(const Instruction& instruction)
         {
             assertm(std::holds_alternative<uint64_t>(vec->elems[i]),
                     "SPIRV simulator: Non-boolean type found in vector operand");
-            result_vec->elems.push_back((uint64_t) !(std::get<uint64_t>(vec->elems[i])));
+            result_vec->elems.push_back((uint64_t)!(std::get<uint64_t>(vec->elems[i])));
         }
 
         SetValue(result_id, result);
@@ -3214,7 +3211,7 @@ void SPIRVSimulator::Op_LogicalNot(const Instruction& instruction)
         Value result;
 
         assertm(std::holds_alternative<uint64_t>(operand), "SPIRV simulator: Non-boolean type found in operand");
-        result = (uint64_t) !(std::get<uint64_t>(operand));
+        result = (uint64_t)!(std::get<uint64_t>(operand));
 
         SetValue(result_id, result);
     }

--- a/framework/spirv_simulator.cpp
+++ b/framework/spirv_simulator.cpp
@@ -6635,7 +6635,7 @@ void SPIRVSimulator::Op_SNegate(const Instruction& instruction)
     }
     else
     {
-        assertx("SPIRV simulator: Invalid result type int, must be vector or integer");
+        assertx("SPIRV simulator: Invalid result type, must be vector or integer");
     }
 }
 

--- a/framework/spirv_simulator.cpp
+++ b/framework/spirv_simulator.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cmath>
 #include <iomanip>
+#include <variant>
 
 namespace SPIRVSimulator
 {
@@ -2702,6 +2703,8 @@ void SPIRVSimulator::Op_FAdd(const Instruction& instruction)
 
         for (uint32_t i = 0; i < type.vector.elem_count; ++i)
         {
+            assertm((std::holds_alternative<double>(vec1->elems[i]) && std::holds_alternative<double>(vec2->elems[i])),
+                    "SPIRV simulator: vector contains non-doubles in Op_FAdd");
             double elem_result = std::get<double>(vec1->elems[i]) + std::get<double>(vec2->elems[i]);
             result_vec->elems.push_back(elem_result);
         }
@@ -2723,7 +2726,7 @@ void SPIRVSimulator::Op_FAdd(const Instruction& instruction)
     }
     else
     {
-        assertx("SPIRV simulator: Invalid result type int Op_FAdd, must be vector or float");
+        assertx("SPIRV simulator: Invalid result type for Op_FAdd, must be vector or float");
     }
 }
 
@@ -2811,6 +2814,8 @@ void SPIRVSimulator::Op_FMul(const Instruction& instruction)
 
         for (uint32_t i = 0; i < type.vector.elem_count; ++i)
         {
+            assertm((std::holds_alternative<double>(vec1->elems[i]) && std::holds_alternative<double>(vec2->elems[i])),
+                    "SPIRV simulator: vector contains non-doubles in Op_FMul");
             double elem_result = std::get<double>(vec1->elems[i]) * std::get<double>(vec2->elems[i]);
             result_vec->elems.push_back(elem_result);
         }
@@ -3057,7 +3062,7 @@ void SPIRVSimulator::Op_IAdd(const Instruction& instruction)
     }
     else
     {
-        assertx("SPIRV simulator: Invalid result type int Op_IAdd, must be vector or int");
+        assertx("SPIRV simulator: Invalid result type for Op_IAdd, must be vector or int");
     }
 }
 
@@ -3092,13 +3097,13 @@ void SPIRVSimulator::Op_ISub(const Instruction& instruction)
 
         assertm(std::holds_alternative<std::shared_ptr<VectorV>>(val_op1) &&
                     std::holds_alternative<std::shared_ptr<VectorV>>(val_op2),
-                "SPIRV simulator: Operands not of vector type in Op_IAdd");
+                "SPIRV simulator: Operands not of vector type in Op_ISub");
 
         auto vec1 = std::get<std::shared_ptr<VectorV>>(val_op1);
         auto vec2 = std::get<std::shared_ptr<VectorV>>(val_op2);
 
         assertm((vec1->elems.size() == vec2->elems.size()) && (vec1->elems.size() == type.vector.elem_count),
-                "SPIRV simulator: Operands not of equal/correct length in Op_IAdd");
+                "SPIRV simulator: Operands not of equal/correct length in Op_ISub");
 
         for (uint32_t i = 0; i < type.vector.elem_count; ++i)
         {
@@ -5291,7 +5296,7 @@ void SPIRVSimulator::Op_FNegate(const Instruction& instruction)
     }
     else
     {
-        assertx("SPIRV simulator: Invalid result type int, must be vector or float");
+        assertx("SPIRV simulator: Invalid result type, must be vector or float");
     }
 }
 

--- a/framework/spirv_simulator.hpp
+++ b/framework/spirv_simulator.hpp
@@ -13,6 +13,7 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
+#include <type_traits>
 
 //  Flip SPIRV_HEADERS_PRESENT to 1 to auto‑pull the SPIR‑V-Headers from the environment.
 #define SPV_ENABLE_UTILITY_CODE 1
@@ -265,24 +266,6 @@ using Value = std::variant<std::monostate,
                            std::shared_ptr<AggregateV>,
                            PointerV>;
 
-struct VectorV
-{
-    std::vector<Value> elems;
-    VectorV() = default;
-    explicit VectorV(std::span<const Value> s) : elems(s.begin(), s.end()) {}
-    explicit VectorV(std::initializer_list<Value> initializer_list) : elems(initializer_list) {}
-};
-
-struct MatrixV
-{
-    std::vector<Value> cols;
-};
-
-struct AggregateV
-{
-    std::vector<Value> elems;
-}; // array or struct
-
 struct PointerV
 {
     // Always the index of the value that this pointer points to
@@ -300,6 +283,99 @@ struct PointerV
     // This is the result_id chain of the objects holding the idx path values
     std::vector<uint32_t> idx_path_ids;
 };
+
+inline bool operator==(const PointerV& a, const PointerV& b)
+{
+    return a.obj_id == b.obj_id && a.type_id == b.type_id && a.storage_class == b.storage_class &&
+           a.raw_pointer == b.raw_pointer && a.idx_path == b.idx_path && a.idx_path_ids == b.idx_path_ids;
+}
+
+struct VectorV
+{
+    std::vector<Value> elems;
+    VectorV() = default;
+
+    template <typename T>
+    explicit VectorV(std::initializer_list<T> initializer_list)
+    {
+        elems.reserve(initializer_list.size());
+        for (const auto& item : initializer_list)
+        {
+            elems.push_back(Value(item));
+        }
+    }
+};
+
+inline bool operator==(const VectorV& a, const VectorV& b)
+{
+    return a.elems == b.elems;
+}
+
+struct MatrixV
+{
+    std::vector<Value> cols;
+    MatrixV() = default;
+
+    explicit MatrixV(std::initializer_list<Value> initializer_list) :
+        cols(initializer_list.begin(), initializer_list.end())
+    {}
+};
+
+inline bool operator==(const MatrixV& a, const MatrixV& b)
+{
+    return a.cols == b.cols;
+}
+
+struct AggregateV
+{
+    std::vector<Value> elems;
+}; // array or struct
+
+inline bool operator==(const AggregateV& a, const AggregateV& b)
+{
+    return a.elems == b.elems;
+}
+
+template <typename T>
+concept Deref = requires(T t) { *t; };
+
+template <typename T>
+concept PointerT = std::is_pointer_v<T> || Deref<T>;
+
+template <typename T>
+concept ValueT = !PointerT<T>;
+
+struct ValueComparator
+{
+    template <ValueT T>
+    bool operator()(T const& a, T const& b) const
+    {
+        return a == b;
+    }
+
+    template <PointerT T>
+    bool operator()(T a, T b) const
+    {
+        if (a && b)
+            return *a == *b;
+        return a == b;
+    }
+
+    template <typename A, typename B>
+    bool operator()(A const&, B const&) const
+    {
+        return false;
+    }
+};
+
+inline bool operator==(const Value& a, const Value& b)
+{
+    if (a.index() != b.index())
+    {
+        return false;
+    }
+    return std::visit(ValueComparator{}, a, b);
+}
 
 struct DecorationInfo
 {

--- a/framework/util.hpp
+++ b/framework/util.hpp
@@ -6,6 +6,10 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <cassert>
+
+#define assertx(msg) assert((void(msg), false))
+#define assertm(exp, msg) assert((void(msg), exp))
 
 namespace util
 {

--- a/test/arithmetic_test.cpp
+++ b/test/arithmetic_test.cpp
@@ -200,81 +200,81 @@ TEST_P(ArithmeticsTest, ArithmeticOperations)
 std::vector<ArithmeticParams> test_cases = {
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpSNegate)
-        .set_op1(SPIRVSimulator::Value(int64_t(1)), Type::i64)
+        .set_op1(int64_t(1), Type::i64)
         .set_op2(SPIRVSimulator::Value(), Type::i64)
-        .set_expected(SPIRVSimulator::Value(-1), Type::i64)
+        .set_expected(-1, Type::i64)
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpFNegate)
-        .set_op1(SPIRVSimulator::Value(1.0), Type::f64)
+        .set_op1(1.0, Type::f64)
         .set_op2(SPIRVSimulator::Value(), Type::f64)
-        .set_expected(SPIRVSimulator::Value(-1.0), Type::f64)
+        .set_expected(-1.0, Type::f64)
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpIAdd)
-        .set_op1(SPIRVSimulator::Value(1), Type::i64)
-        .set_op2(SPIRVSimulator::Value(2), Type::i64)
-        .set_expected(SPIRVSimulator::Value(3), Type::i64)
+        .set_op1(1, Type::i64)
+        .set_op2(2, Type::i64)
+        .set_expected(3, Type::i64)
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpFAdd)
-        .set_op1(SPIRVSimulator::Value(1.0), Type::f64)
-        .set_op2(SPIRVSimulator::Value(2.0), Type::f64)
-        .set_expected(SPIRVSimulator::Value(3.0), Type::f64)
+        .set_op1(1.0, Type::f64)
+        .set_op2(2.0, Type::f64)
+        .set_expected(3.0, Type::f64)
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpISub)
-        .set_op1(SPIRVSimulator::Value(uint64_t(1)), Type::u64)
-        .set_op2(SPIRVSimulator::Value(2), Type::i64)
-        .set_expected(SPIRVSimulator::Value(std::numeric_limits<uint64_t>::max()), Type::u64)
+        .set_op1(uint64_t(1), Type::u64)
+        .set_op2(2, Type::i64)
+        .set_expected(std::numeric_limits<uint64_t>::max(), Type::u64)
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpISub)
-        .set_op1(SPIRVSimulator::Value(1), Type::i64)
-        .set_op2(SPIRVSimulator::Value(2), Type::i64)
-        .set_expected(SPIRVSimulator::Value(-1), Type::i64)
+        .set_op1(1, Type::i64)
+        .set_op2(2, Type::i64)
+        .set_expected(-1, Type::i64)
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpFSub)
-        .set_op1(SPIRVSimulator::Value(1.0), Type::f64)
-        .set_op2(SPIRVSimulator::Value(2.0), Type::f64)
-        .set_expected(SPIRVSimulator::Value(-1.0), Type::f64)
+        .set_op1(1.0, Type::f64)
+        .set_op2(2.0, Type::f64)
+        .set_expected(-1.0, Type::f64)
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpIMul)
-        .set_op1(SPIRVSimulator::Value(2), Type::i64)
-        .set_op2(SPIRVSimulator::Value(2), Type::i64)
-        .set_expected(SPIRVSimulator::Value(4), Type::i64)
+        .set_op1(2, Type::i64)
+        .set_op2(2, Type::i64)
+        .set_expected(4, Type::i64)
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpFMul)
-        .set_op1(SPIRVSimulator::Value(2.0), Type::f64)
-        .set_op2(SPIRVSimulator::Value(2.0), Type::f64)
-        .set_expected(SPIRVSimulator::Value(4.0), Type::f64)
+        .set_op1(2.0, Type::f64)
+        .set_op2(2.0, Type::f64)
+        .set_expected(4.0, Type::f64)
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpSDiv)
-        .set_op1(SPIRVSimulator::Value(-5), Type::i64)
-        .set_op2(SPIRVSimulator::Value(2), Type::i64)
-        .set_expected(SPIRVSimulator::Value(-2), Type::i64)
+        .set_op1(-5, Type::i64)
+        .set_op2(2, Type::i64)
+        .set_expected(-2, Type::i64)
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpUDiv)
-        .set_op1(SPIRVSimulator::Value(uint64_t(5)), Type::u64)
-        .set_op2(SPIRVSimulator::Value(uint64_t(2)), Type::u64)
-        .set_expected(SPIRVSimulator::Value(uint64_t(2)), Type::u64)
+        .set_op1(uint64_t(5), Type::u64)
+        .set_op2(uint64_t(2), Type::u64)
+        .set_expected(uint64_t(2), Type::u64)
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpFDiv)
-        .set_op1(SPIRVSimulator::Value(1.0), Type::f64)
-        .set_op2(SPIRVSimulator::Value(3.0), Type::f64)
-        .set_expected(SPIRVSimulator::Value(1.0 / 3.0), Type::f64)
+        .set_op1(1.0, Type::f64)
+        .set_op2(3.0, Type::f64)
+        .set_expected(1.0 / 3.0, Type::f64)
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpUMod)
-        .set_op1(SPIRVSimulator::Value(uint64_t(13)), Type::u64)
-        .set_op2(SPIRVSimulator::Value(uint64_t(6)), Type::u64)
-        .set_expected(SPIRVSimulator::Value(uint64_t(1)), Type::u64)
+        .set_op1(uint64_t(13), Type::u64)
+        .set_op2(uint64_t(6), Type::u64)
+        .set_expected(uint64_t(1), Type::u64)
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpIAdd)
@@ -320,32 +320,27 @@ std::vector<ArithmeticParams> test_cases = {
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpMatrixTimesVector)
-        .set_op1(
-            std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
-                SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 })),
-                SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 4.0 })) }),
-            Type::mat2)
+        .set_op1(std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
+                     std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 }),
+                     std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 4.0 }) }),
+                 Type::mat2)
         .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 }), Type::vec2)
         .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 7.0, 10.0 }), Type::vec2)
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpMatrixTimesMatrix)
-        .set_op1(
-            std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
-                SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 })),
-                SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 4.0 })) }),
-            Type::mat2)
-        .set_op2(
-            std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
-                SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 })),
-                SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 4.0 })) }),
-            Type::mat2)
-        .set_expected(
-            std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
-                SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 7.0, 10.0 })),
-                SPIRVSimulator::Value(
-                    std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 15.0, 22.0 })) }),
-            Type::mat2)
+        .set_op1(std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
+                     std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 }),
+                     std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 4.0 }) }),
+                 Type::mat2)
+        .set_op2(std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
+                     std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 }),
+                     std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 4.0 }) }),
+                 Type::mat2)
+        .set_expected(std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
+                          std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 7.0, 10.0 }),
+                          std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 15.0, 22.0 }) }),
+                      Type::mat2)
         .build(),
     ArithmeticParamsBuilder()
         .set_opcode(spv::Op::OpDot)

--- a/test/arithmetic_test.cpp
+++ b/test/arithmetic_test.cpp
@@ -1,12 +1,8 @@
 #include <array>
 #include <cstdint>
-#include <initializer_list>
-#include <limits>
-#include <memory>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <variant>
 
 #include "spirv.hpp"
 #include "spirv_simulator.hpp"
@@ -14,339 +10,214 @@
 
 using namespace testing;
 
-char opcode_to_char(spv::Op opcode)
-{
-    switch (opcode)
-    {
-        case spv::OpIAdd:
-        case spv::OpFAdd:
-        {
-            return '+';
-        }
-        case spv::OpISub:
-        case spv::OpFSub:
-        case spv::OpSNegate:
-        {
-            return '-';
-        }
-        case spv::OpIMul:
-        case spv::OpFMul:
-        case spv::OpVectorTimesScalar:
-        case spv::OpDot:
-        {
-            return '*';
-        }
-        case spv::OpMatrixTimesVector:
-        case spv::OpMatrixTimesMatrix:
-        {
-            return 'x';
-        }
-        case spv::OpSDiv:
-        case spv::OpUDiv:
-        case spv::OpFDiv:
-        {
-            return '/';
-        }
-        default:
-            return ' ';
-    }
-}
 
-enum Type : uint32_t
-{
-    void_t  = 0,
-    boolean = 1,
-    i64     = 2,
-    u64     = 3,
-    f64     = 4,
 
-    ivec2 = 5,
-    uvec2 = 6,
-    vec2  = 7,
-
-    mat2 = 8,
-
-    num_types = 9
-};
-
-std::array<SPIRVSimulator::Type, Type::num_types> types_ = { SPIRVSimulator::Type(),
-                                                             SPIRVSimulator::Type::Bool(),
-                                                             SPIRVSimulator::Type::Int(64, true),
-                                                             SPIRVSimulator::Type::Int(64, false),
-                                                             SPIRVSimulator::Type::Float(32),
-                                                             SPIRVSimulator::Type::Vector(Type::i64, 2),
-                                                             SPIRVSimulator::Type::Vector(Type::u64, 2),
-                                                             SPIRVSimulator::Type::Vector(Type::f64, 2),
-                                                             SPIRVSimulator::Type::Matrix(Type::vec2, 2) };
-
-SPIRVSimulator::Type get(uint32_t type_id)
-{
-    return types_[type_id];
-}
-
-class ArithmeticsMock : public SPIRVSimulatorMockBase
-{
-  public:
-    MOCK_METHOD(void, SetValue, (uint32_t id, const ::SPIRVSimulator::Value& value), (override));
-    MOCK_METHOD(::SPIRVSimulator::Value&, GetValue, (uint32_t id), (override));
-
-    MOCK_METHOD(::SPIRVSimulator::Type, GetTypeByTypeId, (uint32_t id), (const override));
-    MOCK_METHOD(::SPIRVSimulator::Type, GetTypeByResultId, (uint32_t id), (const override));
-};
-
-struct ArithmeticParams
-{
-    spv::Op               opcode;
-    SPIRVSimulator::Value op1;
-    Type                  op1_type;
-    SPIRVSimulator::Value op2;
-    Type                  op2_type;
-    SPIRVSimulator::Value expected;
-    Type                  expected_type;
-
-    friend std::ostream& operator<<(std::ostream& os, ArithmeticParams const& p)
-    {
-        // In case of unary operation, op2 is empty and obsolete
-        if (std::holds_alternative<std::monostate>(p.op2))
-        {
-            os << opcode_to_char(p.opcode) << p.op1 << " = " << p.expected;
-            return os;
-        }
-        else
-        {
-            os << p.op1 << ' ' << opcode_to_char(p.opcode) << ' ' << p.op2 << " = " << p.expected;
-        }
-        return os;
-    }
-};
-
-struct ArithmeticParamsBuilder
-{
-    ArithmeticParams build()
-    {
-        ArithmeticParams temp = params;
-        params                = {};
-        return temp;
-    }
-    ArithmeticParams params;
-
-    ArithmeticParamsBuilder& set_opcode(spv::Op opcode)
-    {
-        params.opcode = opcode;
-        return *this;
-    }
-    ArithmeticParamsBuilder& set_op1(const SPIRVSimulator::Value& v, Type t)
-    {
-        params.op1      = v;
-        params.op1_type = t;
-        return *this;
-    }
-    ArithmeticParamsBuilder& set_op2(const SPIRVSimulator::Value& v, Type t)
-    {
-        params.op2      = v;
-        params.op2_type = t;
-        return *this;
-    }
-    ArithmeticParamsBuilder& set_expected(const SPIRVSimulator::Value& v, Type t)
-    {
-        params.expected      = v;
-        params.expected_type = t;
-        return *this;
-    }
-};
-
-class ArithmeticsTest : public TestWithParam<ArithmeticParams>
-{
-  public:
-    ArithmeticsTest()
-    {
-        for (uint32_t i = 0; i < types_.size(); ++i)
-        {
-            EXPECT_CALL(mock, GetTypeByTypeId(i)).WillRepeatedly(Return(types_[i]));
-        }
-    }
-    uint32_t NextId() { return id_counter++; }
-
-  protected:
-    uint32_t        id_counter = Type::num_types;
-    ArithmeticsMock mock;
-};
+class ArithmeticsTest : public SPIRVSimulatorMockBase, public TestWithParam<TestParameters>
+{};
 
 TEST_P(ArithmeticsTest, ArithmeticOperations)
 {
     const auto& parameters = GetParam();
 
-    const uint32_t lhs_id = NextId();
-    EXPECT_CALL(mock, GetValue(lhs_id)).WillRepeatedly(ReturnRefOfCopy(parameters.op1));
-    EXPECT_CALL(mock, GetTypeByResultId(lhs_id)).WillRepeatedly(Return(types_[parameters.op1_type]));
+    const uint32_t        result_id = NextId();
+    std::vector<uint32_t> words{ parameters.opcode, parameters.operand_types[0], result_id };
 
-    const uint32_t rhs_id = NextId();
-    EXPECT_CALL(mock, GetValue(rhs_id)).WillRepeatedly(ReturnRefOfCopy(parameters.op2));
-    EXPECT_CALL(mock, GetTypeByResultId(rhs_id)).WillRepeatedly(Return(types_[parameters.op2_type]));
+    for (uint32_t op = 1; op < parameters.operands.size(); ++op)
+    {
+        const uint32_t op_id = NextId();
+        words.push_back(op_id);
+        EXPECT_CALL(*this, GetValue(op_id)).WillRepeatedly(ReturnRefOfCopy(parameters.operands[op]));
+        EXPECT_CALL(*this, GetTypeByResultId(op_id)).WillRepeatedly(Return(types_[parameters.operand_types[op]]));
+    }
 
-    SPIRVSimulator::Value captured_value;
-    EXPECT_CALL(mock, SetValue(_, _)).WillOnce(SaveArg<1>(&captured_value));
+    ::SPIRVSimulator::Instruction inst{ .opcode     = parameters.opcode,
+                                        .word_count = static_cast<uint16_t>(words.size()),
+                                        .words      = words };
 
-    const uint32_t              result_id = NextId();
-    std::vector<uint32_t>       words{ parameters.opcode, parameters.expected_type, result_id, lhs_id, rhs_id };
-    SPIRVSimulator::Instruction inst{ .opcode     = parameters.opcode,
-                                      .word_count = static_cast<uint16_t>(words.size()),
-                                      .words      = words };
-    mock.ExecuteInstruction(inst);
+    ::SPIRVSimulator::Value captured_value;
+    EXPECT_CALL(*this, SetValue(_, _)).WillOnce(SaveArg<1>(&captured_value));
 
-    EXPECT_EQ(captured_value, parameters.expected);
+    this->ExecuteInstruction(inst);
+
+    EXPECT_EQ(captured_value, parameters.operands[0]);
 }
 
-std::vector<ArithmeticParams> test_cases = {
-    ArithmeticParamsBuilder()
+std::vector<TestParameters> test_cases = {
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpSNegate)
-        .set_op1(int64_t(1), Type::i64)
-        .set_op2(SPIRVSimulator::Value(), Type::i64)
-        .set_expected(-1, Type::i64)
+        .set_operands_size(2)
+        .set_op_n(0, -1, Type::i64)
+        .set_op_n(1, int64_t(1), Type::i64)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpFNegate)
-        .set_op1(1.0, Type::f64)
-        .set_op2(SPIRVSimulator::Value(), Type::f64)
-        .set_expected(-1.0, Type::f64)
+        .set_operands_size(2)
+        .set_op_n(0, -1.0, Type::f64)
+        .set_op_n(1, 1.0, Type::f64)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpIAdd)
-        .set_op1(1, Type::i64)
-        .set_op2(2, Type::i64)
-        .set_expected(3, Type::i64)
+        .set_operands_size(3)
+        .set_op_n(0, 3, Type::i64)
+        .set_op_n(1, 1, Type::i64)
+        .set_op_n(2, 2, Type::i64)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpFAdd)
-        .set_op1(1.0, Type::f64)
-        .set_op2(2.0, Type::f64)
-        .set_expected(3.0, Type::f64)
+        .set_operands_size(3)
+        .set_op_n(0, 3.0, Type::f64)
+        .set_op_n(1, 1.0, Type::f64)
+        .set_op_n(2, 2.0, Type::f64)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpISub)
-        .set_op1(uint64_t(1), Type::u64)
-        .set_op2(2, Type::i64)
-        .set_expected(std::numeric_limits<uint64_t>::max(), Type::u64)
+        .set_operands_size(3)
+        .set_op_n(0, std::numeric_limits<uint64_t>::max(), Type::u64)
+        .set_op_n(1, uint64_t(1), Type::u64)
+        .set_op_n(2, 2, Type::i64)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpISub)
-        .set_op1(1, Type::i64)
-        .set_op2(2, Type::i64)
-        .set_expected(-1, Type::i64)
+        .set_operands_size(3)
+        .set_op_n(0, -1, Type::i64)
+        .set_op_n(1, 1, Type::i64)
+        .set_op_n(2, 2, Type::i64)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpFSub)
-        .set_op1(1.0, Type::f64)
-        .set_op2(2.0, Type::f64)
-        .set_expected(-1.0, Type::f64)
+        .set_operands_size(3)
+        .set_op_n(0, -1.0, Type::f64)
+        .set_op_n(1, 1.0, Type::f64)
+        .set_op_n(2, 2.0, Type::f64)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpIMul)
-        .set_op1(2, Type::i64)
-        .set_op2(2, Type::i64)
-        .set_expected(4, Type::i64)
+        .set_operands_size(3)
+        .set_op_n(0, 4, Type::i64)
+        .set_op_n(1, 2, Type::i64)
+        .set_op_n(2, 2, Type::i64)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpFMul)
-        .set_op1(2.0, Type::f64)
-        .set_op2(2.0, Type::f64)
-        .set_expected(4.0, Type::f64)
+        .set_operands_size(3)
+        .set_op_n(0, 4.0, Type::f64)
+        .set_op_n(1, 2.0, Type::f64)
+        .set_op_n(2, 2.0, Type::f64)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpSDiv)
-        .set_op1(-5, Type::i64)
-        .set_op2(2, Type::i64)
-        .set_expected(-2, Type::i64)
+        .set_operands_size(3)
+        .set_op_n(0, -2, Type::i64)
+        .set_op_n(1, -5, Type::i64)
+        .set_op_n(2, 2, Type::i64)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpUDiv)
-        .set_op1(uint64_t(5), Type::u64)
-        .set_op2(uint64_t(2), Type::u64)
-        .set_expected(uint64_t(2), Type::u64)
+        .set_operands_size(3)
+        .set_op_n(0, uint64_t(2), Type::u64)
+        .set_op_n(1, uint64_t(5), Type::u64)
+        .set_op_n(2, uint64_t(2), Type::u64)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpFDiv)
-        .set_op1(1.0, Type::f64)
-        .set_op2(3.0, Type::f64)
-        .set_expected(1.0 / 3.0, Type::f64)
+        .set_operands_size(3)
+        .set_op_n(0, 1.0 / 3.0, Type::f64)
+        .set_op_n(1, 1.0, Type::f64)
+        .set_op_n(2, 3.0, Type::f64)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpUMod)
-        .set_op1(uint64_t(13), Type::u64)
-        .set_op2(uint64_t(6), Type::u64)
-        .set_expected(uint64_t(1), Type::u64)
+        .set_operands_size(3)
+        .set_op_n(0, uint64_t(1), Type::u64)
+        .set_op_n(1, uint64_t(13), Type::u64)
+        .set_op_n(2, uint64_t(6), Type::u64)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpIAdd)
-        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
-        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
-        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 4, 4 }), Type::ivec2)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 4, 4 }), Type::ivec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpISub)
-        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1 }), Type::ivec2)
-        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
-        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1, -1 }), Type::ivec2)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1, -1 }), Type::ivec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1 }), Type::ivec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpFAdd)
-        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
-        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
-        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 4.0, 4.0 }), Type::vec2)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 4.0, 4.0 }), Type::vec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpFSub)
-        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
-        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
-        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1.0, -1.0 }), Type::vec2)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1.0, -1.0 }), Type::vec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpIMul)
-        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1, -1 }), Type::ivec2)
-        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
-        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -2, -2 }), Type::ivec2)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -2, -2 }), Type::ivec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1, -1 }), Type::ivec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpFMul)
-        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1.0, -1.0 }), Type::vec2)
-        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
-        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -2.0, -2.0 }), Type::vec2)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -2.0, -2.0 }), Type::vec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1.0, -1.0 }), Type::vec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpVectorTimesScalar)
-        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1.0, -1.0 }), Type::vec2)
-        .set_op2(2.0, Type::f64)
-        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -2.0, -2.0 }), Type::vec2)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -2.0, -2.0 }), Type::vec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1.0, -1.0 }), Type::vec2)
+        .set_op_n(2, 2.0, Type::f64)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpMatrixTimesVector)
-        .set_op1(std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
-                     std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 }),
-                     std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 4.0 }) }),
-                 Type::mat2)
-        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 }), Type::vec2)
-        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 7.0, 10.0 }), Type::vec2)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 7.0, 10.0 }), Type::vec2)
+        .set_op_n(1,
+                  std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
+                      std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 }),
+                      std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 4.0 }) }),
+                  Type::mat2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 }), Type::vec2)
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpMatrixTimesMatrix)
-        .set_op1(std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
-                     std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 }),
-                     std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 4.0 }) }),
-                 Type::mat2)
-        .set_op2(std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
-                     std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 }),
-                     std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 4.0 }) }),
-                 Type::mat2)
-        .set_expected(std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
-                          std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 7.0, 10.0 }),
-                          std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 15.0, 22.0 }) }),
-                      Type::mat2)
+        .set_operands_size(3)
+        .set_op_n(0,
+                  std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
+                      std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 7.0, 10.0 }),
+                      std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 15.0, 22.0 }) }),
+                  Type::mat2)
+        .set_op_n(1,
+                  std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
+                      std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 }),
+                      std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 4.0 }) }),
+                  Type::mat2)
+        .set_op_n(2,
+                  std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
+                      std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 }),
+                      std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 4.0 }) }),
+                  Type::mat2)
+
         .build(),
-    ArithmeticParamsBuilder()
+    TestParametersBuilder()
         .set_opcode(spv::Op::OpDot)
-        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
-        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
-        .set_expected(8.0, Type::f64)
+        .set_operands_size(3)
+        .set_op_n(0, 8.0, Type::f64)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
         .build()
 };
 

--- a/test/arithmetic_test.cpp
+++ b/test/arithmetic_test.cpp
@@ -1,10 +1,12 @@
 #include <array>
 #include <cstdint>
+#include <initializer_list>
 #include <limits>
 #include <memory>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <variant>
 
 #include "spirv.hpp"
 #include "spirv_simulator.hpp"
@@ -23,13 +25,21 @@ char opcode_to_char(spv::Op opcode)
         }
         case spv::OpISub:
         case spv::OpFSub:
+        case spv::OpSNegate:
         {
             return '-';
         }
         case spv::OpIMul:
         case spv::OpFMul:
+        case spv::OpVectorTimesScalar:
+        case spv::OpDot:
         {
             return '*';
+        }
+        case spv::OpMatrixTimesVector:
+        case spv::OpMatrixTimesMatrix:
+        {
+            return 'x';
         }
         case spv::OpSDiv:
         case spv::OpUDiv:
@@ -42,6 +52,38 @@ char opcode_to_char(spv::Op opcode)
     }
 }
 
+enum Type : uint32_t
+{
+    void_t  = 0,
+    boolean = 1,
+    i64     = 2,
+    u64     = 3,
+    f64     = 4,
+
+    ivec2 = 5,
+    uvec2 = 6,
+    vec2  = 7,
+
+    mat2 = 8,
+
+    num_types = 9
+};
+
+std::array<SPIRVSimulator::Type, Type::num_types> types_ = { SPIRVSimulator::Type(),
+                                                             SPIRVSimulator::Type::Bool(),
+                                                             SPIRVSimulator::Type::Int(64, true),
+                                                             SPIRVSimulator::Type::Int(64, false),
+                                                             SPIRVSimulator::Type::Float(32),
+                                                             SPIRVSimulator::Type::Vector(Type::i64, 2),
+                                                             SPIRVSimulator::Type::Vector(Type::u64, 2),
+                                                             SPIRVSimulator::Type::Vector(Type::f64, 2),
+                                                             SPIRVSimulator::Type::Matrix(Type::vec2, 2) };
+
+SPIRVSimulator::Type get(uint32_t type_id)
+{
+    return types_[type_id];
+}
+
 class ArithmeticsMock : public SPIRVSimulatorMockBase
 {
   public:
@@ -49,49 +91,69 @@ class ArithmeticsMock : public SPIRVSimulatorMockBase
     MOCK_METHOD(::SPIRVSimulator::Value&, GetValue, (uint32_t id), (override));
 
     MOCK_METHOD(::SPIRVSimulator::Type, GetTypeByTypeId, (uint32_t id), (const override));
+    MOCK_METHOD(::SPIRVSimulator::Type, GetTypeByResultId, (uint32_t id), (const override));
 };
 
 struct ArithmeticParams
 {
     spv::Op               opcode;
-    SPIRVSimulator::Value lhs;
-    SPIRVSimulator::Value rhs;
+    SPIRVSimulator::Value op1;
+    Type                  op1_type;
+    SPIRVSimulator::Value op2;
+    Type                  op2_type;
     SPIRVSimulator::Value expected;
-    uint32_t              expected_type_id;
+    Type                  expected_type;
 
     friend std::ostream& operator<<(std::ostream& os, ArithmeticParams const& p)
     {
-        os << p.lhs << ' ' << opcode_to_char(p.opcode) << ' ' << p.rhs << " = " << p.expected;
+        // In case of unary operation, op2 is empty and obsolete
+        if (std::holds_alternative<std::monostate>(p.op2))
+        {
+            os << opcode_to_char(p.opcode) << p.op1 << " = " << p.expected;
+            return os;
+        }
+        else
+        {
+            os << p.op1 << ' ' << opcode_to_char(p.opcode) << ' ' << p.op2 << " = " << p.expected;
+        }
         return os;
     }
 };
 
-enum Type : uint32_t
+struct ArithmeticParamsBuilder
 {
-    boolean = 0,
-    i64     = 1,
-    u64     = 2,
-    f64     = 3,
+    ArithmeticParams build()
+    {
+        ArithmeticParams temp = params;
+        params                = {};
+        return temp;
+    }
+    ArithmeticParams params;
 
-    ivec2 = 4,
-    uvec2 = 5,
-    vec2  = 6,
-
-    num_types = 7
+    ArithmeticParamsBuilder& set_opcode(spv::Op opcode)
+    {
+        params.opcode = opcode;
+        return *this;
+    }
+    ArithmeticParamsBuilder& set_op1(const SPIRVSimulator::Value& v, Type t)
+    {
+        params.op1      = v;
+        params.op1_type = t;
+        return *this;
+    }
+    ArithmeticParamsBuilder& set_op2(const SPIRVSimulator::Value& v, Type t)
+    {
+        params.op2      = v;
+        params.op2_type = t;
+        return *this;
+    }
+    ArithmeticParamsBuilder& set_expected(const SPIRVSimulator::Value& v, Type t)
+    {
+        params.expected      = v;
+        params.expected_type = t;
+        return *this;
+    }
 };
-
-std::array<SPIRVSimulator::Type, Type::num_types> types_ = { SPIRVSimulator::Type::Bool(),
-                                                             SPIRVSimulator::Type::Int(64, true),
-                                                             SPIRVSimulator::Type::Int(64, false),
-                                                             SPIRVSimulator::Type::Float(32),
-                                                             SPIRVSimulator::Type::Vector(Type::i64, 2),
-                                                             SPIRVSimulator::Type::Vector(Type::u64, 2),
-                                                             SPIRVSimulator::Type::Vector(Type::f64, 2) };
-
-SPIRVSimulator::Type get(uint32_t type_id)
-{
-    return types_[type_id];
-}
 
 class ArithmeticsTest : public TestWithParam<ArithmeticParams>
 {
@@ -110,183 +172,187 @@ class ArithmeticsTest : public TestWithParam<ArithmeticParams>
     ArithmeticsMock mock;
 };
 
-// clang-format off
-std::vector<ArithmeticParams> scalar_cases = {
-    { spv::Op::OpIAdd,
-      SPIRVSimulator::Value(int64_t(1)),
-      SPIRVSimulator::Value(int64_t(2)),
-      SPIRVSimulator::Value(int64_t(3)),
-      Type::i64 },
-    { spv::Op::OpFAdd,
-      SPIRVSimulator::Value(double(1.0)),
-      SPIRVSimulator::Value(double(2.0)),
-      SPIRVSimulator::Value(double(3.0)),
-      Type::f64 },
-    { spv::Op::OpISub,
-      SPIRVSimulator::Value(uint64_t(1)),
-      SPIRVSimulator::Value(int64_t(2)),
-      SPIRVSimulator::Value(std::numeric_limits<uint64_t>::max()),
-      Type::u64 },
-    { spv::Op::OpISub,
-      SPIRVSimulator::Value(int64_t(1)),
-      SPIRVSimulator::Value(int64_t(2)),
-      SPIRVSimulator::Value(int64_t(-1)),
-      Type::i64 },
-    { spv::Op::OpFSub,
-      SPIRVSimulator::Value(1.0),
-      SPIRVSimulator::Value(2.0),
-      SPIRVSimulator::Value(-1.0),
-      Type::f64 },
-    { spv::Op::OpIMul,
-      SPIRVSimulator::Value(int64_t(2)),
-      SPIRVSimulator::Value(int64_t(2)),
-      SPIRVSimulator::Value(int64_t(4)),
-      Type::i64 },
-    { spv::Op::OpFMul,
-      SPIRVSimulator::Value(2.0),
-      SPIRVSimulator::Value(2.0),
-      SPIRVSimulator::Value(4.0),
-      Type::f64 },
-    { spv::Op::OpSDiv,
-      SPIRVSimulator::Value(int64_t(-5)),
-      SPIRVSimulator::Value(int64_t(2)),
-      SPIRVSimulator::Value(int64_t(-2)),
-      Type::i64 },
-    { spv::Op::OpUDiv,
-      SPIRVSimulator::Value(uint64_t(5)),
-      SPIRVSimulator::Value(uint64_t(2)),
-      SPIRVSimulator::Value(uint64_t(2)),
-      Type::u64 },
-};
-
-// clang-format on
-
-class ScalarTests : public ArithmeticsTest
-{};
-
-TEST_P(ScalarTests, ScalarOperations)
+TEST_P(ArithmeticsTest, ArithmeticOperations)
 {
     const auto& parameters = GetParam();
 
     const uint32_t lhs_id = NextId();
-    EXPECT_CALL(mock, GetValue(lhs_id)).WillRepeatedly(ReturnRefOfCopy(parameters.lhs));
+    EXPECT_CALL(mock, GetValue(lhs_id)).WillRepeatedly(ReturnRefOfCopy(parameters.op1));
+    EXPECT_CALL(mock, GetTypeByResultId(lhs_id)).WillRepeatedly(Return(types_[parameters.op1_type]));
 
     const uint32_t rhs_id = NextId();
-    EXPECT_CALL(mock, GetValue(rhs_id)).WillRepeatedly(ReturnRefOfCopy(parameters.rhs));
+    EXPECT_CALL(mock, GetValue(rhs_id)).WillRepeatedly(ReturnRefOfCopy(parameters.op2));
+    EXPECT_CALL(mock, GetTypeByResultId(rhs_id)).WillRepeatedly(Return(types_[parameters.op2_type]));
 
     SPIRVSimulator::Value captured_value;
     EXPECT_CALL(mock, SetValue(_, _)).WillOnce(SaveArg<1>(&captured_value));
 
     const uint32_t              result_id = NextId();
-    std::vector<uint32_t>       words{ parameters.opcode, parameters.expected_type_id, result_id, lhs_id, rhs_id };
+    std::vector<uint32_t>       words{ parameters.opcode, parameters.expected_type, result_id, lhs_id, rhs_id };
     SPIRVSimulator::Instruction inst{ .opcode     = parameters.opcode,
                                       .word_count = static_cast<uint16_t>(words.size()),
                                       .words      = words };
     mock.ExecuteInstruction(inst);
 
-    if (parameters.expected_type_id == Type::i64)
-    {
-        EXPECT_EQ(std::get<int64_t>(captured_value), std::get<int64_t>(parameters.expected));
-    }
-    else if (parameters.expected_type_id == Type::u64)
-    {
-        EXPECT_EQ(std::get<uint64_t>(captured_value), std::get<uint64_t>(parameters.expected));
-    }
-    else if (parameters.expected_type_id == Type::f64)
-    {
-        EXPECT_EQ(std::get<double>(captured_value), std::get<double>(parameters.expected));
-    }
-    else if (parameters.expected_type_id == Type::boolean)
-    {
-        EXPECT_EQ(std::get<uint64_t>(captured_value), std::get<uint64_t>(parameters.expected));
-    }
+    EXPECT_EQ(captured_value, parameters.expected);
 }
 
-INSTANTIATE_TEST_SUITE_P(Arithmetics, ScalarTests, ValuesIn(scalar_cases));
-
-class VectorTests : public ArithmeticsTest
-{};
-
-// clang-format off
-std::vector<ArithmeticParams> vector_cases = {
-    { spv::Op::OpIAdd,
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ 2, 2 })),
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ 2, 2 })),
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ 4, 4 })),
-      Type::ivec2 },
-    { spv::Op::OpFAdd,
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ 2.0, 2.0 })),
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ 2.0, 2.0 })),
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ 4.0, 4.0 })),
-      Type::vec2 },
-    { spv::Op::OpISub,
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ 1, 1 })),
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ 2, 2 })),
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ -1, -1 })),
-      Type::ivec2 },
-    { spv::Op::OpFSub,
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ 1.0, 1.0 })),
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ 2.0, 2.0 })),
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ -1.0, -1.0 })),
-      Type::vec2 },
-    { spv::Op::OpIMul,
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ -1, -1 })),
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ 2, 2 })),
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ -2, -2 })),
-      Type::ivec2 },
-    { spv::Op::OpFMul,
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ -1.0, -1.0 })),
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ 2.0, 2.0 })),
-      SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::vector<SPIRVSimulator::Value>{ -2.0, -2.0 })),
-      Type::vec2 }
+std::vector<ArithmeticParams> test_cases = {
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpSNegate)
+        .set_op1(SPIRVSimulator::Value(int64_t(1)), Type::i64)
+        .set_op2(SPIRVSimulator::Value(), Type::i64)
+        .set_expected(SPIRVSimulator::Value(-1), Type::i64)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpFNegate)
+        .set_op1(SPIRVSimulator::Value(1.0), Type::f64)
+        .set_op2(SPIRVSimulator::Value(), Type::f64)
+        .set_expected(SPIRVSimulator::Value(-1.0), Type::f64)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpIAdd)
+        .set_op1(SPIRVSimulator::Value(1), Type::i64)
+        .set_op2(SPIRVSimulator::Value(2), Type::i64)
+        .set_expected(SPIRVSimulator::Value(3), Type::i64)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpFAdd)
+        .set_op1(SPIRVSimulator::Value(1.0), Type::f64)
+        .set_op2(SPIRVSimulator::Value(2.0), Type::f64)
+        .set_expected(SPIRVSimulator::Value(3.0), Type::f64)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpISub)
+        .set_op1(SPIRVSimulator::Value(uint64_t(1)), Type::u64)
+        .set_op2(SPIRVSimulator::Value(2), Type::i64)
+        .set_expected(SPIRVSimulator::Value(std::numeric_limits<uint64_t>::max()), Type::u64)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpISub)
+        .set_op1(SPIRVSimulator::Value(1), Type::i64)
+        .set_op2(SPIRVSimulator::Value(2), Type::i64)
+        .set_expected(SPIRVSimulator::Value(-1), Type::i64)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpFSub)
+        .set_op1(SPIRVSimulator::Value(1.0), Type::f64)
+        .set_op2(SPIRVSimulator::Value(2.0), Type::f64)
+        .set_expected(SPIRVSimulator::Value(-1.0), Type::f64)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpIMul)
+        .set_op1(SPIRVSimulator::Value(2), Type::i64)
+        .set_op2(SPIRVSimulator::Value(2), Type::i64)
+        .set_expected(SPIRVSimulator::Value(4), Type::i64)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpFMul)
+        .set_op1(SPIRVSimulator::Value(2.0), Type::f64)
+        .set_op2(SPIRVSimulator::Value(2.0), Type::f64)
+        .set_expected(SPIRVSimulator::Value(4.0), Type::f64)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpSDiv)
+        .set_op1(SPIRVSimulator::Value(-5), Type::i64)
+        .set_op2(SPIRVSimulator::Value(2), Type::i64)
+        .set_expected(SPIRVSimulator::Value(-2), Type::i64)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpUDiv)
+        .set_op1(SPIRVSimulator::Value(uint64_t(5)), Type::u64)
+        .set_op2(SPIRVSimulator::Value(uint64_t(2)), Type::u64)
+        .set_expected(SPIRVSimulator::Value(uint64_t(2)), Type::u64)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpFDiv)
+        .set_op1(SPIRVSimulator::Value(1.0), Type::f64)
+        .set_op2(SPIRVSimulator::Value(3.0), Type::f64)
+        .set_expected(SPIRVSimulator::Value(1.0 / 3.0), Type::f64)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpUMod)
+        .set_op1(SPIRVSimulator::Value(uint64_t(13)), Type::u64)
+        .set_op2(SPIRVSimulator::Value(uint64_t(6)), Type::u64)
+        .set_expected(SPIRVSimulator::Value(uint64_t(1)), Type::u64)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpIAdd)
+        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
+        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
+        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 4, 4 }), Type::ivec2)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpISub)
+        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1 }), Type::ivec2)
+        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
+        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1, -1 }), Type::ivec2)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpFAdd)
+        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
+        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
+        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 4.0, 4.0 }), Type::vec2)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpFSub)
+        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
+        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1.0, -1.0 }), Type::vec2)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpIMul)
+        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1, -1 }), Type::ivec2)
+        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
+        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -2, -2 }), Type::ivec2)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpFMul)
+        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1.0, -1.0 }), Type::vec2)
+        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
+        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -2.0, -2.0 }), Type::vec2)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpVectorTimesScalar)
+        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1.0, -1.0 }), Type::vec2)
+        .set_op2(2.0, Type::f64)
+        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -2.0, -2.0 }), Type::vec2)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpMatrixTimesVector)
+        .set_op1(
+            std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
+                SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 })),
+                SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 4.0 })) }),
+            Type::mat2)
+        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 }), Type::vec2)
+        .set_expected(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 7.0, 10.0 }), Type::vec2)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpMatrixTimesMatrix)
+        .set_op1(
+            std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
+                SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 })),
+                SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 4.0 })) }),
+            Type::mat2)
+        .set_op2(
+            std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
+                SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 2.0 })),
+                SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 4.0 })) }),
+            Type::mat2)
+        .set_expected(
+            std::make_shared<SPIRVSimulator::MatrixV>(std::initializer_list<SPIRVSimulator::Value>{
+                SPIRVSimulator::Value(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 7.0, 10.0 })),
+                SPIRVSimulator::Value(
+                    std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 15.0, 22.0 })) }),
+            Type::mat2)
+        .build(),
+    ArithmeticParamsBuilder()
+        .set_opcode(spv::Op::OpDot)
+        .set_op1(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
+        .set_op2(std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
+        .set_expected(8.0, Type::f64)
+        .build()
 };
 
-// clang-format on
-
-TEST_P(VectorTests, VectorOperations)
-{
-    const auto& parameters = GetParam();
-
-    const uint32_t lhs_id = NextId();
-    EXPECT_CALL(mock, GetValue(lhs_id)).WillRepeatedly(::ReturnRefOfCopy(parameters.lhs));
-    const uint32_t rhs_id = NextId();
-    EXPECT_CALL(mock, GetValue(rhs_id)).WillRepeatedly(::ReturnRefOfCopy(parameters.rhs));
-
-    SPIRVSimulator::Value captured_value;
-    EXPECT_CALL(mock, SetValue(_, _)).WillOnce(SaveArg<1>(&captured_value));
-
-    const uint32_t              result_id = NextId();
-    std::vector<uint32_t>       words{ parameters.opcode, parameters.expected_type_id, result_id, lhs_id, rhs_id };
-    SPIRVSimulator::Instruction instruction{ .opcode = parameters.opcode, .word_count = 5, .words = words };
-
-    mock.ExecuteInstruction(instruction);
-
-    const auto& result = std::get<std::shared_ptr<SPIRVSimulator::VectorV>>(captured_value);
-    const std::vector<SPIRVSimulator::Value>& elems = result->elems;
-
-    std::shared_ptr<SPIRVSimulator::VectorV> expected =
-        std::get<std::shared_ptr<SPIRVSimulator::VectorV>>(parameters.expected);
-    if (parameters.expected_type_id == ivec2)
-    {
-        for (uint32_t i = 0; i < elems.size(); ++i)
-        {
-            EXPECT_EQ(std::get<int64_t>(elems[i]), std::get<int64_t>(expected->elems[i]));
-        }
-    }
-    else if (parameters.expected_type_id == uvec2)
-    {
-        for (uint32_t i = 0; i < elems.size(); ++i)
-        {
-            EXPECT_EQ(std::get<uint64_t>(elems[i]), std::get<uint64_t>(expected->elems[i]));
-        }
-    }
-    else if (parameters.expected_type_id == vec2)
-    {
-        for (uint32_t i = 0; i < elems.size(); ++i)
-        {
-            EXPECT_EQ(std::get<double>(elems[i]), std::get<double>(expected->elems[i]));
-        }
-    }
-}
-
-INSTANTIATE_TEST_SUITE_P(Arithmetics, VectorTests, ValuesIn(vector_cases));
+INSTANTIATE_TEST_SUITE_P(Arithmetics, ArithmeticsTest, ValuesIn(test_cases));

--- a/test/arithmetic_test.cpp
+++ b/test/arithmetic_test.cpp
@@ -1,8 +1,9 @@
-#include <array>
 #include <cstdint>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <initializer_list>
+#include <memory>
 
 #include "spirv.hpp"
 #include "spirv_simulator.hpp"
@@ -10,12 +11,10 @@
 
 using namespace testing;
 
-
-
-class ArithmeticsTest : public SPIRVSimulatorMockBase, public TestWithParam<TestParameters>
+class ArithmeticsTests : public SPIRVSimulatorMockBase, public TestWithParam<TestParameters>
 {};
 
-TEST_P(ArithmeticsTest, ArithmeticOperations)
+TEST_P(ArithmeticsTests, ParametrizedArithmeticOperation)
 {
     const auto& parameters = GetParam();
 
@@ -221,4 +220,346 @@ std::vector<TestParameters> test_cases = {
         .build()
 };
 
-INSTANTIATE_TEST_SUITE_P(Arithmetics, ArithmeticsTest, ValuesIn(test_cases));
+INSTANTIATE_TEST_SUITE_P(Arithmetics, ArithmeticsTests, ValuesIn(test_cases));
+
+// Death tests cannot work without Debug build, as they rely on program crashing with certain message in stderr
+// Also, they are slow
+#ifndef NDEBUG
+
+class ArithmeticsDeathTests : public SPIRVSimulatorMockBase, public TestWithParam<TestParameters>
+{};
+
+TEST_P(ArithmeticsDeathTests, ParametrizedDeathTest)
+{
+    const auto& parameters = GetParam();
+
+    const uint32_t        result_id = NextId();
+    std::vector<uint32_t> words{ parameters.opcode, parameters.operand_types[0], result_id };
+
+    for (uint32_t op = 1; op < parameters.operands.size(); ++op)
+    {
+        const uint32_t op_id = NextId();
+        words.push_back(op_id);
+        EXPECT_CALL(*this, GetValue(op_id)).WillRepeatedly(ReturnRefOfCopy(parameters.operands[op]));
+        EXPECT_CALL(*this, GetTypeByResultId(op_id)).WillRepeatedly(Return(types_[parameters.operand_types[op]]));
+    }
+
+    ::SPIRVSimulator::Instruction inst{ .opcode     = parameters.opcode,
+                                        .word_count = static_cast<uint16_t>(words.size()),
+                                        .words      = words };
+
+    EXPECT_DEATH({ this->ExecuteInstruction(inst); }, parameters.death_message);
+}
+
+std::vector<TestParameters> death_tests = {
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpSNegate)
+        .set_operands_size(2)
+        .set_op_n(0, -1.0, Type::f64)
+        .set_op_n(1, int64_t(1), Type::i64)
+        .set_death_message("Invalid result type")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpSNegate)
+        .set_operands_size(2)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1, -1 }), Type::ivec2)
+        .set_op_n(1, int64_t(1), Type::i64)
+        .set_death_message("Operand not of vector type")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpSNegate)
+        .set_operands_size(2)
+        .set_op_n(0, int64_t(1), Type::i64)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1, -1 }), Type::ivec2)
+        .set_death_message("Operands not of int type")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFNegate)
+        .set_operands_size(2)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1.0, -1.0 }), Type::vec2)
+        .set_op_n(1, 1.0, Type::f64)
+        .set_death_message("Operand not of vector type")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFNegate)
+        .set_operands_size(2)
+        .set_op_n(0, 1.0, Type::f64)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1.0, -1.0 }), Type::vec2)
+        .set_death_message("Operands not of float type")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFNegate)
+        .set_operands_size(2)
+        .set_op_n(0, 1, Type::i64)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ -1.0, -1.0 }), Type::vec2)
+        .set_death_message("Invalid result type, must be vector or float")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpIAdd)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3, 3 }), Type::ivec2)
+        .set_op_n(1, 1, Type::i64)
+        .set_op_n(2, 2, Type::i64)
+        .set_death_message("Operands not of vector type in Op_IAdd")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpIAdd)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3, 3, 3 }), Type::ivec3)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1 }), Type::ivec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
+        .set_death_message("Operands not of equal/correct length in Op_IAdd")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpIAdd)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3, 3 }), Type::ivec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1, 1 }), Type::ivec3)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
+        .set_death_message("Operands not of equal/correct length in Op_IAdd")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpIAdd)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3, 3 }), Type::ivec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
+        .set_death_message("Could not find valid parameter type combination for Op_IAdd vector operand")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpIAdd)
+        .set_operands_size(3)
+        .set_op_n(0, 3, Type::i64)
+        .set_op_n(1, 1.0, Type::f64)
+        .set_op_n(2, 2, Type::i64)
+        .set_death_message("Could not find valid parameter type combination for Op_IAdd")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpIAdd)
+        .set_operands_size(3)
+        .set_op_n(0, 3.0, Type::f64)
+        .set_op_n(1, 1, Type::i64)
+        .set_op_n(2, 2, Type::i64)
+        .set_death_message("Invalid result type for Op_IAdd, must be vector or int")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFAdd)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 3.0 }), Type::vec2)
+        .set_op_n(1, 1.0, Type::f64)
+        .set_op_n(2, 2.0, Type::f64)
+        .set_death_message("Operands not of vector type in Op_FAdd")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFAdd)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 3.0, 3.0 }), Type::vec3)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
+        .set_death_message("Operands not of equal/correct length in Op_FAdd")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFAdd)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 3.0 }), Type::vec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0, 1.0 }), Type::vec3)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2.0, 2.0 }), Type::vec2)
+        .set_death_message("Operands not of equal/correct length in Op_FAdd")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFAdd)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 3.0, 3.0 }), Type::vec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 2, 2 }), Type::ivec2)
+        .set_death_message("SPIRV simulator: vector contains non-doubles in Op_FAdd")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFAdd)
+        .set_operands_size(3)
+        .set_op_n(0, 3.0, Type::f64)
+        .set_op_n(1, 1.0, Type::f64)
+        .set_op_n(2, 2, Type::i64)
+        .set_death_message("SPIRV simulator: Operands not of float type in Op_FAdd")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFAdd)
+        .set_operands_size(3)
+        .set_op_n(0, 3, Type::i64)
+        .set_op_n(1, 1.0, Type::f64)
+        .set_op_n(2, 2.0, Type::f64)
+        .set_death_message("Invalid result type for Op_FAdd, must be vector or float")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpISub)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1 }), Type::ivec2)
+        .set_op_n(1, 1, Type::i64)
+        .set_op_n(2, 0, Type::i64)
+        .set_death_message("Operands not of vector type in Op_ISub")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpISub)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1 }), Type::ivec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1, 1 }), Type::ivec3)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 0, 0 }), Type::ivec2)
+        .set_death_message("Operands not of equal/correct length in Op_ISub")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpISub)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1, 1 }), Type::ivec3)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1 }), Type::ivec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 0, 0 }), Type::ivec2)
+        .set_death_message("Operands not of equal/correct length in Op_ISub")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpISub)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1 }), Type::ivec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 0, 0 }), Type::ivec2)
+        .set_death_message("Could not find valid parameter type combination for Op_ISub vector operand")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpISub)
+        .set_operands_size(3)
+        .set_op_n(0, 1, Type::i64)
+        .set_op_n(1, 1, Type::u64)
+        .set_op_n(2, 0.0, Type::f64)
+        .set_death_message("Could not find valid parameter type combination for Op_ISub")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpISub)
+        .set_operands_size(3)
+        .set_op_n(0, 1, Type::f64)
+        .set_op_n(1, 1, Type::u64)
+        .set_op_n(2, 0, Type::i64)
+        .set_death_message("Invalid result type int Op_ISub, must be vector or int")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFSub)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_op_n(1, 0, Type::i64)
+        .set_op_n(2, 1, Type::i64)
+        .set_death_message("Operands set to be vector type in Op_FSub, but they are not, illegal input parameters")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFSub)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0, 1.0 }), Type::vec3)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 0.0, 0.0 }), Type::vec2)
+        .set_death_message("Operands are vector type but not of equal length in Op_FSub")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFSub)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1 }), Type::ivec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 0.0, 0.0 }), Type::vec2)
+        .set_death_message("Found non-floating point operand in Op_FSub vector operand")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFSub)
+        .set_operands_size(3)
+        .set_op_n(0, 1.0, Type::f64)
+        .set_op_n(1, 1, Type::i64)
+        .set_op_n(2, 0.0, Type::f64)
+        .set_death_message("Found non-floating point operand in Op_FSub")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFSub)
+        .set_operands_size(3)
+        .set_op_n(0, 1, Type::i64)
+        .set_op_n(1, 1.0, Type::f64)
+        .set_op_n(2, 0.0, Type::f64)
+        .set_death_message("Invalid result type int Op_FSub, must be vector or float")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpIMul)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1 }), Type::ivec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1 }), Type::ivec2)
+        .set_op_n(2, 0, Type::i64)
+        .set_death_message("Operands not of vector type in Op_IMul")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpIMul)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1, 1 }), Type::ivec3)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1 }), Type::ivec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1 }), Type::ivec2)
+        .set_death_message("Operands not of equal/correct length in Op_IMul")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpIMul)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1, 1 }), Type::ivec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1 }), Type::ivec2)
+        .set_death_message("Could not find valid parameter type combination for Op_IMul vector operand")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpIMul)
+        .set_operands_size(3)
+        .set_op_n(0, 2, Type::i64)
+        .set_op_n(1, 2, Type::i64)
+        .set_op_n(2, 1.0, f64)
+        .set_death_message("Could not find valid parameter type combination for Op_IMul")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpIMul)
+        .set_operands_size(3)
+        .set_op_n(0, 2.0, Type::f64)
+        .set_op_n(1, 2, Type::i64)
+        .set_op_n(2, 1, i64)
+        .set_death_message("Invalid result type int Op_IMul, must be vector or integer type")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFMul)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_op_n(1, 2.0, Type::f64)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_death_message("Operands not of vector type in Op_FMul")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFMul)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0, 1.0 }), Type::vec3)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_death_message("Operands not of equal/correct length in Op_FMul")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFMul)
+        .set_operands_size(3)
+        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1, 1 }), Type::ivec2)
+        .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list{ 1.0, 1.0 }), Type::vec2)
+        .set_death_message("vector contains non-doubles in Op_FMul")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFMul)
+        .set_operands_size(3)
+        .set_op_n(0, 2.0, Type::f64)
+        .set_op_n(1, 2.0, Type::f64)
+        .set_op_n(2, 1, Type::i64)
+        .set_death_message("Operands are not floats/doubles in Op_FMul")
+        .build(),
+    TestParametersBuilder()
+        .set_opcode(spv::Op::OpFMul)
+        .set_operands_size(3)
+        .set_op_n(0, 2, Type::i64)
+        .set_op_n(1, 2.0, Type::f64)
+        .set_op_n(2, 1.0, Type::f64)
+        .set_death_message("Invalid result type int Op_FMul, must be vector or float")
+        .build(),
+};
+
+INSTANTIATE_TEST_SUITE_P(Arithmetics, ArithmeticsDeathTests, ValuesIn(death_tests));
+
+#endif

--- a/test/testing_common.cpp
+++ b/test/testing_common.cpp
@@ -2,6 +2,7 @@
 #include "spirv_simulator.hpp"
 #include <cstdint>
 #include <memory>
+#include <variant>
 
 std::ostream& operator<<(std::ostream& os, const SPIRVSimulator::Value& value)
 {
@@ -21,14 +22,34 @@ std::ostream& operator<<(std::ostream& os, const SPIRVSimulator::Value& value)
                  std::get_if<std::shared_ptr<SPIRVSimulator::VectorV>>(&value))
     {
         const std::shared_ptr<SPIRVSimulator::VectorV>& inner = *inner_vec;
+        const std::vector<SPIRVSimulator::Value>&       elems = inner->elems;
         os << "(";
-        for (uint32_t i = 0; i < inner->elems.size() - 1; ++i)
+        for (uint32_t i = 0; i < elems.size() - 1; ++i)
         {
-            os << inner->elems[i] << ",";
+            os << elems[i] << ",";
         }
-        os << inner->elems.back() << ")";
+        os << elems.back() << ")";
     }
-    // TODO for matrix, aggregate and pointer
+    else if (const std::shared_ptr<SPIRVSimulator::MatrixV>* inner_mat =
+                 std::get_if<std::shared_ptr<SPIRVSimulator::MatrixV>>(&value))
+    {
+        const std::shared_ptr<SPIRVSimulator::MatrixV>& inner   = *inner_mat;
+        const std::vector<SPIRVSimulator::Value>&       columns = inner->cols;
+        const uint32_t rows = std::get<std::shared_ptr<SPIRVSimulator::VectorV>>(columns[0])->elems.size();
+        os << '(';
+        for (uint32_t i = 0; i < rows; ++i)
+        {
+            os << '(';
+            for (uint32_t j = 0; j < columns.size() - 1; ++j)
+            {
+                os << std::get<std::shared_ptr<SPIRVSimulator::VectorV>>(columns[j])->elems[i] << ',';
+            }
+            os << std::get<std::shared_ptr<SPIRVSimulator::VectorV>>(columns[columns.size() - 1])->elems[i];
+            os << ")";
+        }
+        os << ')';
+    }
+    // TODO for aggregate and pointer
     else
         os << "<invalid>";
     return os;

--- a/test/testing_common.cpp
+++ b/test/testing_common.cpp
@@ -54,3 +54,41 @@ std::ostream& operator<<(std::ostream& os, const SPIRVSimulator::Value& value)
         os << "<invalid>";
     return os;
 }
+
+char opcode_to_char(spv::Op opcode)
+{
+    switch (opcode)
+    {
+        case spv::OpIAdd:
+        case spv::OpFAdd:
+        {
+            return '+';
+        }
+        case spv::OpISub:
+        case spv::OpFSub:
+        case spv::OpSNegate:
+        {
+            return '-';
+        }
+        case spv::OpIMul:
+        case spv::OpFMul:
+        case spv::OpVectorTimesScalar:
+        case spv::OpDot:
+        {
+            return '*';
+        }
+        case spv::OpMatrixTimesVector:
+        case spv::OpMatrixTimesMatrix:
+        {
+            return 'x';
+        }
+        case spv::OpSDiv:
+        case spv::OpUDiv:
+        case spv::OpFDiv:
+        {
+            return '/';
+        }
+        default:
+            return ' ';
+    }
+}

--- a/test/testing_common.hpp
+++ b/test/testing_common.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #ifndef ARM_TESTING_COMMON_HPP
 #define ARM_TESTING_COMMON_HPP
 
@@ -10,15 +11,139 @@
 
 #include <spirv_simulator.hpp>
 
+using namespace testing;
+
+char opcode_to_char(spv::Op opcode);
+
 std::ostream& operator<<(std::ostream& os, SPIRVSimulator::Value const& v);
+
+enum Type : uint32_t
+{
+    void_t = 0,
+    boolean,
+    i64,
+    u64,
+    f64,
+
+    ivec2,
+    uvec2,
+    vec2,
+    ivec3,
+    uvec3,
+    vec3,
+    ivec4,
+    uvec4,
+    vec4,
+
+    mat2,
+    mat2x3,
+    mat2x4,
+    mat3,
+    mat3x2,
+    mat3x4,
+    mat4,
+    mat4x2,
+    mat4x3,
+
+    num_types
+};
+
+struct TestParameters
+{
+    spv::Op                            opcode;
+    std::vector<SPIRVSimulator::Value> operands;
+    std::vector<Type>                  operand_types;
+
+    friend std::ostream& operator<<(std::ostream& os, TestParameters const& p)
+    {
+        os << opcode_to_char(p.opcode) << " ";
+        for (uint32_t i = 0; i < p.operands.size() - 1; ++i)
+        {
+            if (!std::holds_alternative<std::monostate>(p.operands[i]))
+            {
+                os << p.operands[i] << " ";
+            }
+        }
+        os << p.operands[p.operands.size() - 1];
+        return os;
+    }
+};
+
+struct TestParametersBuilder
+{
+    TestParameters build() { return params; }
+    TestParameters params;
+
+    TestParametersBuilder& set_opcode(spv::Op opcode)
+    {
+        params.opcode = opcode;
+        return *this;
+    }
+
+    TestParametersBuilder& set_operands_size(uint32_t n)
+    {
+        params.operands.resize(n);
+        params.operand_types.resize(n);
+        return *this;
+    }
+
+    TestParametersBuilder& set_op_n(uint32_t n, const SPIRVSimulator::Value& v, Type t)
+    {
+        params.operands[n]      = v;
+        params.operand_types[n] = t;
+        return *this;
+    }
+};
 
 class SPIRVSimulatorMockBase : public SPIRVSimulator::SPIRVSimulator
 {
   public:
-    SPIRVSimulatorMockBase() { RegisterOpcodeHandlers(); }
+    MOCK_METHOD(void, SetValue, (uint32_t id, const ::SPIRVSimulator::Value& value), (override));
+    MOCK_METHOD(::SPIRVSimulator::Value&, GetValue, (uint32_t id), (override));
+
+    MOCK_METHOD(::SPIRVSimulator::Type, GetTypeByTypeId, (uint32_t id), (const override));
+    MOCK_METHOD(::SPIRVSimulator::Type, GetTypeByResultId, (uint32_t id), (const override));
+
+    SPIRVSimulatorMockBase()
+    {
+        RegisterOpcodeHandlers();
+        types_ = {
+            { Type::void_t, ::SPIRVSimulator::Type() },
+            { Type::boolean, ::SPIRVSimulator::Type::Bool() },
+            { Type::i64, ::SPIRVSimulator::Type::Int(64, true) },
+            { Type::u64, ::SPIRVSimulator::Type::Int(64, false) },
+            { Type::f64, ::SPIRVSimulator::Type::Float(32) },
+            { Type::ivec2, ::SPIRVSimulator::Type::Vector(Type::i64, 2) },
+            { Type::uvec2, ::SPIRVSimulator::Type::Vector(Type::u64, 2) },
+            { Type::vec2, ::SPIRVSimulator::Type::Vector(Type::f64, 2) },
+            { Type::ivec3, ::SPIRVSimulator::Type::Vector(Type::i64, 3) },
+            { Type::uvec3, ::SPIRVSimulator::Type::Vector(Type::u64, 3) },
+            { Type::vec3, ::SPIRVSimulator::Type::Vector(Type::f64, 3) },
+            { Type::ivec4, ::SPIRVSimulator::Type::Vector(Type::i64, 4) },
+            { Type::uvec4, ::SPIRVSimulator::Type::Vector(Type::u64, 4) },
+            { Type::vec4, ::SPIRVSimulator::Type::Vector(Type::f64, 4) },
+            { Type::mat2, ::SPIRVSimulator::Type::Matrix(Type::vec2, 2) },
+            { Type::mat2x3, ::SPIRVSimulator::Type::Matrix(Type::vec2, 3) },
+            { Type::mat2x4, ::SPIRVSimulator::Type::Matrix(Type::vec2, 4) },
+            { Type::mat3, ::SPIRVSimulator::Type::Matrix(Type::vec3, 3) },
+            { Type::mat3x2, ::SPIRVSimulator::Type::Matrix(Type::vec3, 2) },
+            { Type::mat3x4, ::SPIRVSimulator::Type::Matrix(Type::vec3, 4) },
+            { Type::mat4, ::SPIRVSimulator::Type::Matrix(Type::vec4, 4) },
+            { Type::mat4x2, ::SPIRVSimulator::Type::Matrix(Type::vec4, 2) },
+            { Type::mat4x3, ::SPIRVSimulator::Type::Matrix(Type::vec4, 3) },
+        };
+        for (const auto& [id, type] : types_)
+        {
+            EXPECT_CALL(*this, GetTypeByTypeId(id)).WillRepeatedly(Return(type));
+        }
+    }
     ~SPIRVSimulatorMockBase() = default;
 
     using SPIRVSimulator::SPIRVSimulator::ExecuteInstruction;
+
+  protected:
+    uint32_t NextId() { return id_counter++; }
+    uint32_t id_counter = Type::num_types;
 };
 
 #endif

--- a/test/testing_common.hpp
+++ b/test/testing_common.hpp
@@ -53,6 +53,7 @@ struct TestParameters
     spv::Op                            opcode;
     std::vector<SPIRVSimulator::Value> operands;
     std::vector<Type>                  operand_types;
+    std::string                        death_message;
 
     friend std::ostream& operator<<(std::ostream& os, TestParameters const& p)
     {
@@ -91,6 +92,11 @@ struct TestParametersBuilder
     {
         params.operands[n]      = v;
         params.operand_types[n] = t;
+        return *this;
+    }
+    TestParametersBuilder& set_death_message(const std::string& message)
+    {
+        params.death_message = message;
         return *this;
     }
 };


### PR DESCRIPTION
Death tests ensure that when the simulator crashes in a predictable way. For now, they are run only in Debug build, as they rely on triggering an assertion. We can also run them in release, if we write the corresponding assertion message into stderr and then call `std::abort`  or `std::terminate`