### PR TITLE
Make crash tests possible in release

### DIFF
--- a/framework/util.hpp
+++ b/framework/util.hpp
@@ -6,10 +6,26 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+
+#ifdef NDEBUG
+#include <stdexcept>
+
+#define assertx(msg) throw std::runtime_error(msg);
+#define assertm(exp, msg)                  \
+    do                                     \
+    {                                      \
+        if (!(exp))                        \
+        {                                  \
+            throw std::runtime_error(msg); \
+        }                                  \
+    } while (0)
+#else
 #include <cassert>
 
 #define assertx(msg) assert((void(msg), false))
 #define assertm(exp, msg) assert((void(msg), exp))
+
+#endif
 
 namespace util
 {

--- a/test/arithmetic_test.cpp
+++ b/test/arithmetic_test.cpp
@@ -224,12 +224,11 @@ INSTANTIATE_TEST_SUITE_P(Arithmetics, ArithmeticsTests, ValuesIn(test_cases));
 
 // Death tests cannot work without Debug build, as they rely on program crashing with certain message in stderr
 // Also, they are slow
-#ifndef NDEBUG
 
-class ArithmeticsDeathTests : public SPIRVSimulatorMockBase, public TestWithParam<TestParameters>
+class ArithmeticsCrashTests : public SPIRVSimulatorMockBase, public TestWithParam<TestParameters>
 {};
 
-TEST_P(ArithmeticsDeathTests, ParametrizedDeathTest)
+TEST_P(ArithmeticsCrashTests, ParametrizedCrashTest)
 {
     const auto& parameters = GetParam();
 
@@ -248,10 +247,21 @@ TEST_P(ArithmeticsDeathTests, ParametrizedDeathTest)
                                         .word_count = static_cast<uint16_t>(words.size()),
                                         .words      = words };
 
+#ifndef NDEBUG
     EXPECT_DEATH({ this->ExecuteInstruction(inst); }, parameters.death_message);
+#else
+    try
+    {
+        this->ExecuteInstruction(inst);
+    }
+    catch (std::runtime_error e)
+    {
+        EXPECT_THAT(e.what(), HasSubstr(parameters.death_message));
+    }
+#endif
 }
 
-std::vector<TestParameters> death_tests = {
+std::vector<TestParameters> throw_tests = {
     TestParametersBuilder()
         .set_opcode(spv::Op::OpSNegate)
         .set_operands_size(2)
@@ -353,7 +363,8 @@ std::vector<TestParameters> death_tests = {
     TestParametersBuilder()
         .set_opcode(spv::Op::OpFAdd)
         .set_operands_size(3)
-        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 3.0, 3.0, 3.0 }), Type::vec3)
+        .set_op_n(
+            0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 3.0, 3.0, 3.0 }), Type::vec3)
         .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 1.0, 1.0 }), Type::vec2)
         .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 2.0, 2.0 }), Type::vec2)
         .set_death_message("Operands not of equal/correct length in Op_FAdd")
@@ -362,7 +373,8 @@ std::vector<TestParameters> death_tests = {
         .set_opcode(spv::Op::OpFAdd)
         .set_operands_size(3)
         .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 3.0, 3.0 }), Type::vec2)
-        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 1.0, 1.0, 1.0 }), Type::vec3)
+        .set_op_n(
+            1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 1.0, 1.0, 1.0 }), Type::vec3)
         .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 2.0, 2.0 }), Type::vec2)
         .set_death_message("Operands not of equal/correct length in Op_FAdd")
         .build(),
@@ -449,7 +461,8 @@ std::vector<TestParameters> death_tests = {
     TestParametersBuilder()
         .set_opcode(spv::Op::OpFSub)
         .set_operands_size(3)
-        .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 1.0, 1.0, 1.0 }), Type::vec3)
+        .set_op_n(
+            0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 1.0, 1.0, 1.0 }), Type::vec3)
         .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 1.0, 1.0 }), Type::vec2)
         .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 0.0, 0.0 }), Type::vec2)
         .set_death_message("Operands are vector type but not of equal length in Op_FSub")
@@ -530,7 +543,8 @@ std::vector<TestParameters> death_tests = {
         .set_opcode(spv::Op::OpFMul)
         .set_operands_size(3)
         .set_op_n(0, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 1.0, 1.0 }), Type::vec2)
-        .set_op_n(1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 1.0, 1.0, 1.0 }), Type::vec3)
+        .set_op_n(
+            1, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 1.0, 1.0, 1.0 }), Type::vec3)
         .set_op_n(2, std::make_shared<SPIRVSimulator::VectorV>(std::initializer_list<double>{ 1.0, 1.0 }), Type::vec2)
         .set_death_message("Operands not of equal/correct length in Op_FMul")
         .build(),
@@ -560,6 +574,4 @@ std::vector<TestParameters> death_tests = {
         .build(),
 };
 
-INSTANTIATE_TEST_SUITE_P(Arithmetics, ArithmeticsDeathTests, ValuesIn(death_tests));
-
-#endif
+INSTANTIATE_TEST_SUITE_P(Arithmetics, ArithmeticsCrashTests, ValuesIn(throw_tests));


### PR DESCRIPTION
Crash tests are made possible in release via throwing an exception rather then asserting.
Using pre-processor, we can check that the code threw or asserted based on the debug build.

This way, we keep asserts in debug builds, but we also get the relevant crash message when crashing in the same way in release.