### PR TITLE
Fix operator == resolution errors on Clang

### DIFF
--- a/framework/spirv_simulator.hpp
+++ b/framework/spirv_simulator.hpp
@@ -316,13 +316,14 @@ struct PointerV
 
 inline bool operator==(const PointerV& a, const PointerV& b)
 {
-    return a.heap_index == b.heap_index && a.type_id == b.type_id && a.result_id == b.result_id && a.storage_class == b.storage_class &&
-           a.raw_pointer == b.raw_pointer && a.idx_path == b.idx_path;
+    return a.heap_index == b.heap_index && a.type_id == b.type_id && a.result_id == b.result_id &&
+           a.storage_class == b.storage_class && a.raw_pointer == b.raw_pointer && a.idx_path == b.idx_path;
 }
 
-struct SampledImageV{
-     uint32_t image_id;
-     uint32_t sampler_id;
+struct SampledImageV
+{
+    uint32_t image_id;
+    uint32_t sampler_id;
 };
 
 inline bool operator==(const SampledImageV& a, const SampledImageV& b)
@@ -348,7 +349,18 @@ struct VectorV
 
 inline bool operator==(const VectorV& a, const VectorV& b)
 {
-    return a.elems == b.elems;
+    if (a.elems.size() != b.elems.size())
+    {
+        return false;
+    }
+    for (size_t i = 0; i < a.elems.size(); ++i)
+    {
+        if (!(a.elems[i] == b.elems[i]))
+        {
+            return false;
+        }
+    }
+    return true;
 }
 
 struct MatrixV
@@ -363,7 +375,24 @@ struct MatrixV
 
 inline bool operator==(const MatrixV& a, const MatrixV& b)
 {
-    return a.cols == b.cols;
+    if (a.cols.size() != b.cols.size())
+    {
+        return false;
+    }
+    for (size_t i = 0; i < a.cols.size(); ++i)
+    {
+        const auto& a_c = std::get<std::shared_ptr<VectorV>>(a.cols[i]);
+        const auto& b_c = std::get<std::shared_ptr<VectorV>>(b.cols[i]);
+        if (!(a_c && b_c))
+        {
+            return false;
+        }
+        if (!(*a_c == *b_c))
+        {
+            return false;
+        }
+    }
+    return true;
 }
 
 struct AggregateV
@@ -373,7 +402,18 @@ struct AggregateV
 
 inline bool operator==(const AggregateV& a, const AggregateV& b)
 {
-    return a.elems == b.elems;
+    if (a.elems.size() != b.elems.size())
+    {
+        return false;
+    }
+    for (size_t i = 0; i < a.elems.size(); ++i)
+    {
+        if (!(a.elems[i] == b.elems[i]))
+        {
+            return false;
+        }
+    }
+    return true;
 }
 
 template <typename T>
@@ -388,7 +428,7 @@ concept ValueT = !PointerT<T>;
 struct ValueComparator
 {
     template <ValueT T>
-    bool operator()(T const& a, T const& b) const
+    bool operator()(const T& a, const T& b) const
     {
         return a == b;
     }
@@ -402,7 +442,7 @@ struct ValueComparator
     }
 
     template <typename A, typename B>
-    bool operator()(A const&, B const&) const
+    bool operator()(const A&, const B&) const
     {
         return false;
     }
@@ -485,7 +525,7 @@ class SPIRVSimulator
   protected:
     SPIRVSimulator() = default;
 
-    uint32_t num_result_ids_ = 0;
+    uint32_t num_result_ids_     = 0;
     uint32_t current_heap_index_ = 0;
 
     // Parsing artefacts
@@ -548,7 +588,7 @@ class SPIRVSimulator
     std::vector<Frame> call_stack_;
 
     // result_id -> Value
-    //std::unordered_map<uint32_t, Value> globals_;
+    // std::unordered_map<uint32_t, Value> globals_;
     std::vector<Value> values_;
     std::vector<Value> function_heap_;
 
@@ -568,7 +608,7 @@ class SPIRVSimulator
     virtual void        ParseAll();
     virtual void        Validate();
     virtual bool        CanEarlyOut();
-    virtual bool        ExecuteInstruction(const Instruction&, bool dummy_exec=false);
+    virtual bool        ExecuteInstruction(const Instruction&, bool dummy_exec = false);
     virtual void        ExecuteInstructions();
     virtual void        CreateExecutionFork(const SPIRVSimulator& source);
     virtual std::string GetValueString(const Value&);
@@ -597,7 +637,8 @@ class SPIRVSimulator
     virtual bool  ValueIsArbitrary(uint32_t result_id) const { return arbitrary_values_.contains(result_id); };
     virtual void  SetIsArbitrary(uint32_t result_id) { arbitrary_values_.insert(result_id); };
     virtual Value CopyValue(const Value& value) const;
-    virtual std::vector<Value>& Heap(uint32_t sc) {
+    virtual std::vector<Value>& Heap(uint32_t sc)
+    {
         if (sc == spv::StorageClass::StorageClassFunction)
         {
             return function_heap_;
@@ -608,7 +649,8 @@ class SPIRVSimulator
         }
     };
 
-    virtual uint32_t HeapAllocate(uint32_t sc, const Value& init) {
+    virtual uint32_t HeapAllocate(uint32_t sc, const Value& init)
+    {
         auto& heap = Heap(sc);
 
         uint32_t return_index = heap.size();


### PR DESCRIPTION
On Clang, we default to library-shipper == instead of applying the deep-compare. 

By defining explicit comparison operators based on underlying types for Value variant, and not relying on standard library calling our overload in std::vector's ==, we avoid that problem.